### PR TITLE
fix: Do not apply retry when status code is 429

### DIFF
--- a/dotnet-advisor-core/AdvisorCore.csproj
+++ b/dotnet-advisor-core/AdvisorCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>0.1.2</Version>
+        <Version>0.1.3</Version>
         <Title>Advisor Core SDK</Title>
         <Description>SDK to access the advisor core API.</Description>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>

--- a/dotnet-advisor-core/README.md
+++ b/dotnet-advisor-core/README.md
@@ -5,6 +5,7 @@ Advisor Software Development Kit for .NET.
 ## Contents
 - [.NET SDK](#net-sdk)
   - [How to get your token](https://www.climatempoconsultoria.com.br/contato/)
+  - [Contents](#contents)
   - [Installation](#installation)
   - [Usage](#usage)
     - [Routes](#routes)

--- a/dotnet-advisor-core/Routes/BaseRouter.cs
+++ b/dotnet-advisor-core/Routes/BaseRouter.cs
@@ -64,7 +64,7 @@ public abstract class BaseRouter(AdvisorCoreConfig config)
                 {
                     var statusCode = (int) response.StatusCode;
 
-                    if (retryNumber == 0 || (statusCode < 500 && statusCode != 429))
+                    if (retryNumber == 0 || (statusCode < 500))
                     {
                         return response;
                     }

--- a/go-advisor-core/fetcher.go
+++ b/go-advisor-core/fetcher.go
@@ -30,7 +30,7 @@ func retryReq(
 		client := &http.Client{}
 
 		res, err = client.Do(req)
-		if (res.StatusCode < 500 && res.StatusCode != 429) || retryNumber == 0 {
+		if (res.StatusCode < 500) || retryNumber == 0 {
 			return res, err
 		}
 

--- a/node-advisor-core/README.md
+++ b/node-advisor-core/README.md
@@ -30,6 +30,11 @@ Advisor Software Development Kit for nodeJS.
     - [RadiusPayload](#radiuspayload)
     - [GeometryPayload](#geometrypayload)
     - [TmsPayload](#tmspayload)
+    - [PlanInfoPayload](#planinfopayload)
+    - [RequestDetailsPayload](#requestdetailspayload)
+    - [StorageListPayload](#storagelistpayload)
+    - [StorageDownloadPayload](#storagedownloadpayload)
+    - [StaticMapPayload](#staticmappayload)
 ---
 
 ## Installation

--- a/node-advisor-core/package-lock.json
+++ b/node-advisor-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stormgeo/advisor-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stormgeo/advisor-core",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/node-advisor-core/package.json
+++ b/node-advisor-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stormgeo/advisor-core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Climatempo",
   "license": "MIT",
   "description": "SDK to access the advisor core API.",

--- a/node-advisor-core/src/AdvisorCore.ts
+++ b/node-advisor-core/src/AdvisorCore.ts
@@ -192,7 +192,7 @@ export class AdvisorCore {
 
       return { data: response.data, error: null }
     } catch (error: any) {
-      if (retries > 0 && (error?.response?.status >= 500 || error?.response?.status == 429)) {
+      if (retries > 0 && (error?.response?.status >= 500)) {
         await sleep(this.delay)
         return this.makeRequest(method, url, params, data, --retries)
       }
@@ -220,7 +220,7 @@ export class AdvisorCore {
       const byteArray  = Buffer.from(response.data)
       return { data: byteArray, error: null }
     } catch (error: any) {
-      if (retries > 0 && (error?.response?.status >= 500 || error?.response?.status == 429)) {
+      if (retries > 0 && (error?.response?.status >= 500)) {
         await sleep(this.delay)
 
         return this.makeRequestFile(method, url, params, data, --retries)
@@ -248,7 +248,7 @@ export class AdvisorCore {
 
       return { data: response.data, error: null }
     } catch (error: any) {
-      if (retries > 0 && (error?.response?.status >= 500 || error?.response?.status == 429)) {
+      if (retries > 0 && (error?.response?.status >= 500)) {
         await sleep(this.delay)
 
         return this.makeRequestFileByStream(method, url, params, data, --retries)

--- a/python-advisor-core/README.md
+++ b/python-advisor-core/README.md
@@ -16,9 +16,9 @@ Advisor Software Development Kit for python.
       - [Monitoring](#monitoring)
       - [Observed](#observed)
       - [Plan Information](#plan-information)
+      - [Schema/Parameter](#schemaparameter)
       - [Static Map](#static-map)
       - [Storage](#storage)
-      - [Schema/Parameter](#schemaparameter)
       - [Tms (Tiles Map Server)](#tms-tiles-map-server)
   - [Headers Configuration](#headers-configuration)
   - [Response Format](#response-format)
@@ -30,7 +30,11 @@ Advisor Software Development Kit for python.
     - [RadiusPayload](#radiuspayload)
     - [GeometryPayload](#geometrypayload)
     - [TmsPayload](#tmspayload)
+    - [PlanInfoPayload](#planinfopayload)
     - [RequestDetailsPayload](#requestdetailspayload)
+    - [StorageListPayload](#storagelistpayload)
+    - [StorageDownloadPayload](#storagedownloadpayload)
+    - [StaticMapPayload](#staticmappayload)
 ---
 ## Importing
 

--- a/python-advisor-core/advisor_core/request_handler.py
+++ b/python-advisor-core/advisor_core/request_handler.py
@@ -32,7 +32,7 @@ class RequestHandler:
                 else:
                     error_message = response.json().get("error", response.text)
                 
-                if status < 500 and status != 429:
+                if status < 500:
                     return {"data": None, "error": error_message}
 
             response.raise_for_status()

--- a/python-advisor-core/setup.py
+++ b/python-advisor-core/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'stormgeo.advisor-core',
-    version = '1.2.0',
+    version = '1.2.1',
     author = 'climatempo',
     packages = find_packages(include=['advisor_core']),
     license = 'MIT',


### PR DESCRIPTION
### Motivation

Make the error response come without retrying the request

### Solution

Remove the statusCode = 429 condition from codes

## ✅ Checklist

- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) as default commits;
- [x] My change respects or improves the architecture defined for the project;
- [ ] I wrote or changed tests associated with my move;
- [ ] I ran the tests linked to my change locally and they passed;
- [x] I've tagged everyone who needs to review/get context on the change.
- [x] I have updated the application version following the [semantic versioning](https://docs.npmjs.com/about-semantic-versioning);
